### PR TITLE
Move xml:space att to fix XSLT error on screen elements

### DIFF
--- a/xsl/step1-ui-d.xsl
+++ b/xsl/step1-ui-d.xsl
@@ -11,7 +11,8 @@ See the accompanying LICENSE file for applicable license.
 <xsl:output method="xml"/>
 
 <xsl:template match="*[contains(@class, ' ui-d/screen ')]">
-  <block xml:space="preserve">
+  <block>
+    <xsl:attribute name="xml:space" select="'preserve'"/>
     <xsl:call-template name="commonatts"/>
     <xsl:apply-templates/>
   </block>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes a bug with handling of `<screen>` elements.

Currently when processing the screen, we generate a `<block>`. The `@xml:space="preserve"` attribute is causing Saxon to preserve spaces from within the XSLT, when the desired effect is actually to have the generated content preserve spaces. As a result, today, we generate `<block xml:space="preserve">`, followed by a newline and several spaces, followed by a call to generate attributes. This results in an XSLT failure:
```
Error: Fatal error during transformation using C:\dita-ot\plugins\org.dita.troff\xsl\dita2troff-ast-shell.xsl: An attribute node (xtrc) cannot be created after the children of the containing element; SystemID: file:/C:/dita-ot/plugins/org.dita.troff/xsl/step1.xsl; Line#: 64; Column#: -1
```

Adding the attribute with `xsl:attribute` prevents the XSLT processor from creating the unwanted text node.
