### PR TITLE
Only increment figure num for titled figures

### DIFF
--- a/xsl/step1.xsl
+++ b/xsl/step1.xsl
@@ -127,7 +127,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- These titles should come out as bold -->
 <xsl:template match="*[contains(@class,' topic/fig ')]/*[contains(@class,' topic/title ')]">
-  <xsl:variable name="fignum" select="count(preceding::*[contains(@class,' topic/fig ')]) + 1" as="xs:integer"/>
+  <xsl:variable name="fignum" select="count(preceding::*[contains(@class,' topic/fig ')][*[contains(@class,' topic/title ')]]) + 1" as="xs:integer"/>
   <block><xsl:call-template name="commonatts"/>
     <text style="bold">
       <xsl:call-template name="getVariable"><xsl:with-param name="id" select="'Figure'"/></xsl:call-template>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

If I have this in my topic:
```
<fig><title>Example A</title><p>sample figure</p></fig>
<fig><p>sample figure</p></fig>
<fig><title>Example B</title><p>sample figure</p></fig>
```
The first figure will come out marked as "Figure 1.", the second figure will not have a caption (as expected), and the third figure will incorrectly come out as "Figure 3" because it counts the one in the middle.

This update just fixes the count to skip figures without titles.

## How Has This Been Tested?

Any topic with the sequence of figures above will work.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_